### PR TITLE
cuda-cupti v13.1.115

### DIFF
--- a/.ci_support/linux_64_.yaml
+++ b/.ci_support/linux_64_.yaml
@@ -6,8 +6,6 @@ c_stdlib:
 - sysroot
 c_stdlib_version:
 - '2.28'
-cdt_name:
-- conda
 channel_sources:
 - conda-forge
 channel_targets:

--- a/.ci_support/linux_aarch64_.yaml
+++ b/.ci_support/linux_aarch64_.yaml
@@ -8,8 +8,6 @@ c_stdlib:
 - sysroot
 c_stdlib_version:
 - '2.28'
-cdt_name:
-- conda
 channel_sources:
 - conda-forge
 channel_targets:

--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@
 # Ignore all files and folders in root
 *
 !/conda-forge.yml
+!/abs.yaml
 
 # Don't ignore any files/folders if the parent folder is 'un-ignored'
 # This also avoids warnings when adding an already-checked file with an ignored parent.

--- a/README.md
+++ b/README.md
@@ -139,12 +139,12 @@ it is possible to build and upload installable packages to the
 [conda-forge](https://anaconda.org/conda-forge) [anaconda.org](https://anaconda.org/)
 channel for Linux, Windows and OSX respectively.
 
-To manage the continuous integration and simplify feedstock maintenance
+To manage the continuous integration and simplify feedstock maintenance,
 [conda-smithy](https://github.com/conda-forge/conda-smithy) has been developed.
 Using the ``conda-forge.yml`` within this repository, it is possible to re-render all of
 this feedstock's supporting files (e.g. the CI configuration files) with ``conda smithy rerender``.
 
-For more information please check the [conda-forge documentation](https://conda-forge.org/docs/).
+For more information, please check the [conda-forge documentation](https://conda-forge.org/docs/).
 
 Terminology
 ===========
@@ -171,7 +171,7 @@ merged, the recipe will be re-built and uploaded automatically to the
 everybody to install and use from the `conda-forge` channel.
 Note that all branches in the conda-forge/cuda-cupti-feedstock are
 immediately built and any created packages are uploaded, so PRs should be based
-on branches in forks and branches in the main repository should only be used to
+on branches in forks, and branches in the main repository should only be used to
 build distinct package versions.
 
 In order to produce a uniquely identifiable distribution:

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,9 @@
+build_parameters:
+  - "--suppress-variables"
+  #- "--skip-existing"
+  - "--error-overlinking"
+
+staging_channel_upload_target: ctk-13.1.1-build-1
+
+channels:
+  - https://staging.continuum.io/pbp/ctk-13.1.1-build-1

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "cuda-cupti" %}
-{% set version = "13.1.75" %}
-{% set lib_version = "2025.4.0" %}
+{% set version = "13.1.115" %}
+{% set lib_version = "2025.4.1" %}
 {% set cuda_version = "13.1" %}
 {% set platform = "linux-x86_64" %}  # [linux64]
 {% set platform = "linux-ppc64le" %}  # [ppc64le]
@@ -19,9 +19,9 @@ package:
 
 source:
   url: https://developer.download.nvidia.com/compute/cuda/redist/cuda_cupti/{{ platform }}/cuda_cupti-{{ platform }}-{{ version }}-archive.{{ extension }}
-  sha256: 8969976d7058adbef34baf57ad8116a70fa9936eb60280637e6304f505c80fea  # [linux64]
-  sha256: f47a6f963b6bf7ecffbf88dae7ab57c6f58fe374f37d632e51e350d506a73ad0  # [aarch64]
-  sha256: b65a436e338bc94fadb9a9d1294d6b4b2fa39e1f7d773f610a32ee899b4d38af  # [win]
+  sha256: c712f0181a63484d843897e39ced6bb32167e79c96181a3ca3fd33626b6a6b11  # [linux64]
+  sha256: 4d81812c493880b8cff8cb38ac858f5b3769ebec3a94f65148f1936e8282913c  # [aarch64]
+  sha256: d3639607f4f46eda784998facd786d68e87f58db392decbb83e4b1e61f69a61a  # [win]
 
 build:
   number: 0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,7 +1,7 @@
 {% set name = "cuda-cupti" %}
-{% set version = "13.0.85" %}
-{% set lib_version = "2025.3.1" %}
-{% set cuda_version = "13.0" %}
+{% set version = "13.1.75" %}
+{% set lib_version = "2025.4.0" %}
+{% set cuda_version = "13.1" %}
 {% set platform = "linux-x86_64" %}  # [linux64]
 {% set platform = "linux-ppc64le" %}  # [ppc64le]
 {% set platform = "linux-sbsa" %}  # [aarch64]
@@ -19,9 +19,9 @@ package:
 
 source:
   url: https://developer.download.nvidia.com/compute/cuda/redist/cuda_cupti/{{ platform }}/cuda_cupti-{{ platform }}-{{ version }}-archive.{{ extension }}
-  sha256: 92fb7e0430521517174c4c171173b888aaa8d78d8762e59752dea2ed14a0ad7d  # [linux64]
-  sha256: f6f34d534cce56f91b1496abf51be3b1559ba879985d34eb89c808004b77513a  # [aarch64]
-  sha256: e739e96415e1fb9a650eaac826f7cd24701e18ae2f7c26b78f3fabaf64c8e39b  # [win]
+  sha256: 8969976d7058adbef34baf57ad8116a70fa9936eb60280637e6304f505c80fea  # [linux64]
+  sha256: f47a6f963b6bf7ecffbf88dae7ab57c6f58fe374f37d632e51e350d506a73ad0  # [aarch64]
+  sha256: b65a436e338bc94fadb9a9d1294d6b4b2fa39e1f7d773f610a32ee899b4d38af  # [win]
 
 build:
   number: 0


### PR DESCRIPTION
cuda-cupti 13.1.115

**Destination channel:** defaults

### Links

- [PKG-12004](https://anaconda.atlassian.net/browse/PKG-12004) 
- Relevant dependency PRs:
  - ...

### Explanation of changes:

- CUDA 13.1 release


[PKG-12004]: https://anaconda.atlassian.net/browse/PKG-12004?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ