### PR TITLE
cuda-cupti v12.9.79

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@
 # Ignore all files and folders in root
 *
 !/conda-forge.yml
+!/abs.yaml
 
 # Don't ignore any files/folders if the parent folder is 'un-ignored'
 # This also avoids warnings when adding an already-checked file with an ignored parent.

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,9 @@
+# build_parameters:
+#   - "--suppress-variables"
+#   #- "--skip-existing"
+#   - "--error-overlinking"
+
+# staging_channel_upload_target: ctk-12.9-build-4
+
+# channels:
+#   - https://staging.continuum.io/pbp/ctk-12.9-build-4

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -1,5 +1,4 @@
+# Please see the note on "arm-variant-feedstock" cbc.yaml file regarding tegra builds
 arm_variant_type: # [aarch64]
   - sbsa          # [aarch64]
-  - tegra         # [aarch64]
-c_stdlib_version:  # [linux]
-  - 2.28           # [linux]
+#  - tegra         # [aarch64]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -27,8 +27,8 @@ source:
   sha256: c96018456dc4db6af6d69d6db0170a2ccc656ddde8c8ce6ee05682c2c5569daa  # [win]
 
 build:
-  number: 1
-  skip: true  # [osx or ppc64le]
+  number: 0
+  skip: true  # [osx]
 
 requirements:
   build:
@@ -39,6 +39,15 @@ outputs:
   - name: cuda-cupti
     build:
       binary_relocation: false
+      missing_dso_whitelist:
+        # Needed for the use of conda-build's --error-overlinking command-line argument
+        - '*libgcc_s.so*'           # [linux]
+      overlinking_ignore_patterns:
+        # Workaround for LIEF's 'not a valid TAG' error
+        - '*libcupti*.so*'          # [linux and aarch64]
+        - '*libnvperf*.so*'         # [linux and aarch64]
+        - '*libcheckpoint.so*'      # [linux and aarch64]
+        - '*libpcsamplingutil.so*'  # [linux and aarch64]
     files:
       - lib/libcupti*.so.*                    # [linux]
       - targets/{{ target_name }}/lib/*.so.*  # [linux]
@@ -79,15 +88,23 @@ outputs:
       license_file: LICENSE
       license: LicenseRef-NVIDIA-End-User-License-Agreement
       license_url: https://docs.nvidia.com/cuda/eula/index.html
+      license_family: Other
       summary: Provides libraries to enable third party tools using GPU profiling APIs.
       description: |
         Provides libraries to enable third party tools using GPU profiling APIs.
       doc_url: https://docs.nvidia.com/cuda/cupti/index.html
+      dev_url: https://docs.nvidia.com/cuda/cupti/index.html
 
   - name: cuda-cupti-dev
     build:
       run_exports:
         - {{ pin_subpackage("cuda-cupti", max_pin="x") }}
+      overlinking_ignore_patterns:
+        # Workaround for LIEF's 'not a valid TAG' error
+        - '*libcupti*.so*'          # [linux and aarch64]
+        - '*libnvperf*.so*'         # [linux and aarch64]
+        - '*libcheckpoint.so*'      # [linux and aarch64]
+        - '*libpcsamplingutil.so*'  # [linux and aarch64]
     files:
       - lib/checkpoint.so                         # [linux]
       - lib/libcupti.so                           # [linux]
@@ -127,10 +144,12 @@ outputs:
       license_file: LICENSE
       license: LicenseRef-NVIDIA-End-User-License-Agreement
       license_url: https://docs.nvidia.com/cuda/eula/index.html
+      license_family: Other
       summary: Provides libraries to enable third party tools using GPU profiling APIs.
       description: |
         Provides libraries to enable third party tools using GPU profiling APIs.
       doc_url: https://docs.nvidia.com/cuda/cupti/index.html
+      dev_url: https://docs.nvidia.com/cuda/cupti/index.html
 
   - name: cuda-cupti-static
     build:
@@ -154,10 +173,12 @@ outputs:
       license_file: LICENSE
       license: LicenseRef-NVIDIA-End-User-License-Agreement
       license_url: https://docs.nvidia.com/cuda/eula/index.html
+      license_family: Other
       summary: Provides libraries to enable third party tools using GPU profiling APIs.
       description: |
         Provides libraries to enable third party tools using GPU profiling APIs.
       doc_url: https://docs.nvidia.com/cuda/cupti/index.html
+      dev_url: https://docs.nvidia.com/cuda/cupti/index.html
 
   - name: cuda-cupti-doc
     files:
@@ -180,21 +201,25 @@ outputs:
       home: https://developer.nvidia.com/cuda-toolkit
       license_file: LICENSE
       license: LicenseRef-NVIDIA-End-User-License-Agreement
+      license_family: Other
       license_url: https://docs.nvidia.com/cuda/eula/index.html
       summary: Provides libraries to enable third party tools using GPU profiling APIs.
       description: |
         Provides libraries to enable third party tools using GPU profiling APIs.
       doc_url: https://docs.nvidia.com/cuda/cupti/index.html
+      dev_url: https://docs.nvidia.com/cuda/cupti/index.html
 
 about:
   home: https://developer.nvidia.com/cuda-toolkit
   license_file: LICENSE
   license: LicenseRef-NVIDIA-End-User-License-Agreement
   license_url: https://docs.nvidia.com/cuda/eula/index.html
+  license_family: Other
   summary: Provides libraries to enable third party tools using GPU profiling APIs.
   description: |
     Provides libraries to enable third party tools using GPU profiling APIs.
   doc_url: https://docs.nvidia.com/cuda/cupti/index.html
+  dev_url: https://docs.nvidia.com/cuda/cupti/index.html
 
 extra:
   feedstock-name: cuda-cupti


### PR DESCRIPTION
cuda-cupti 12.9.79

**Destination channel:** defaults

### Links

- [PKG-12771](https://anaconda.atlassian.net/browse/PKG-12771) 
- [CUDA 12.9 release notes](https://docs.nvidia.com/cuda/archive/12.9.1/cuda-toolkit-release-notes/index.html) for list of packages, version numbers, etc.

### Explanation of changes:

- CUDA 12.9 release
- Added `abs.yaml` for possible use of staging channels in future builds


[PKG-12771]: https://anaconda.atlassian.net/browse/PKG-12771?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ